### PR TITLE
fix: use federalreservebanks holiday definition for ACH files

### DIFF
--- a/lib/ach/next_federal_reserve_effective_date.rb
+++ b/lib/ach/next_federal_reserve_effective_date.rb
@@ -6,7 +6,7 @@ module ACH
       if Gem.loaded_specs['holidays'].version < Gem::Version.new('7.0.0')
         :federal_reserve
       else
-        :federalreserve
+        :federalreservebanks
       end
     def initialize(submission_date)
       @submission_date = submission_date

--- a/spec/ach/next_federal_reserve_effective_date_spec.rb
+++ b/spec/ach/next_federal_reserve_effective_date_spec.rb
@@ -36,6 +36,14 @@ describe ACH::NextFederalReserveEffectiveDate do
       end
     end
 
+    context 'when today is Thursday and tomorrow is a observed holiday' do
+      let(:run_date) { Date.new(2023, 11, 9) }
+
+      it 'returns tomorrow' do
+        expect(subject).to eq(Date.new(2023, 11, 10))
+      end
+    end
+
     context 'when today is Monday and a holiday' do
       let(:run_date) { Date.new(2012, 5, 28) }
 


### PR DESCRIPTION
ACH file should use `federalreservebanks` holiday definition as banks in US follow a slightly different holiday calendar than the one defined in `federalreserve` holiday definition. For example, banks are open on Fridays when a holiday falls on a Saturday and Friday is a observed holiday.