### PR TITLE
[PAY-797] Fix Forked Ach Gem

### DIFF
--- a/lib/ach/ach_file.rb
+++ b/lib/ach/ach_file.rb
@@ -166,7 +166,7 @@ module ACH
         Date.today.to_datetime + (same_day_hour + same_day_minute/60) / 24
       end
 
-      date_time || ACH::Data.parse(date_string)
+      date_time || Date.parse(date_string)
     rescue
       date_string
     end


### PR DESCRIPTION
ACH::Data.parse does not exist updated it to Date.parse
tested out the functionality of the method locally and seems to work at parsing dates from ach files - would originally be something like - "240108" into Mon, 08 Jan 2024 (when using Date.parse)